### PR TITLE
Плагин для кастомной роли scp 035 с hsm

### DIFF
--- a/SCP035/Commands.cs
+++ b/SCP035/Commands.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using CommandSystem;
+using Exiled.API.Features;
+using Exiled.Permissions.Extensions;
+
+namespace SCP035
+{
+    [CommandHandler(typeof(RemoteAdminCommandHandler))]
+    [CommandHandler(typeof(GameConsoleCommandHandler))]
+    public class Scp035Command : ICommand
+    {
+        public string Command => "scp035";
+        public string[] Aliases => new[] { "035" };
+        public string Description => "Управление SCP-035: info, give <userid>, respawn, set <userid>, map";
+
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            if (!sender.CheckPermission("scp035.admin"))
+            {
+                response = "❌ Нет прав.";
+                return false;
+            }
+
+            if (arguments.Count == 0)
+            {
+                response = "Использование: scp035 info | scp035 give <userid> | scp035 respawn";
+                return false;
+            }
+
+            switch (arguments.At(0).ToLower())
+            {
+                case "info":
+                    response = $"Активных масок на карте: {Plugin.Instance.spawnedMasks.Count(m => m != null && m.IsSpawned)}";
+                    return true;
+
+                case "give":
+                    if (arguments.Count < 2)
+                    {
+                        response = "Использование: scp035 give <userid>";
+                        return false;
+                    }
+                    var player = Player.Get(arguments.At(1));
+                    if (player == null)
+                    {
+                        response = "Игрок не найден.";
+                        return false;
+                    }
+                    player.AddItem(Exiled.API.Enums.ItemType.SCP268);
+                    response = $"Выдана маска SCP-035 игроку {player.Nickname}.";
+                    return true;
+
+                case "respawn":
+                    Plugin.Instance.TrySpawnMasksAtRoundStart();
+                    response = "Маски перезаспавнены по текущим настройкам.";
+                    return true;
+
+                case "set":
+                    if (arguments.Count < 2)
+                    {
+                        response = "Использование: scp035 set <userid>";
+                        return false;
+                    }
+                    var p2 = Player.Get(arguments.At(1));
+                    if (p2 == null)
+                    {
+                        response = "Игрок не найден.";
+                        return false;
+                    }
+                    PluginUtils.ForceBecome035(p2);
+                    response = $"Игрок {p2.Nickname} стал носителем SCP-035.";
+                    return true;
+
+                case "map":
+                    var groups = Plugin.Instance.spawnedMasks
+                        .Where(pk => pk != null && pk.IsSpawned)
+                        .GroupBy(pk =>
+                        {
+                            var room = Exiled.API.Features.Room.FindParentRoom(pk.GameObject);
+                            return room != null ? room.Zone : Exiled.API.Enums.ZoneType.Unspecified;
+                        })
+                        .OrderBy(g => g.Key);
+
+                    response = "Маски SCP-035 по зонам:\n";
+                    foreach (var g in groups)
+                        response += $"{g.Key}: {g.Count()}\n";
+                    return true;
+            }
+
+            response = "Неизвестная подкоманда.";
+            return false;
+        }
+    }
+}

--- a/SCP035/Config.cs
+++ b/SCP035/Config.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Exiled.API.Enums;
+using Exiled.API.Interfaces;
+
+namespace SCP035
+{
+    public class Config : IConfig
+    {
+        [Description("Включен ли плагин")] 
+        public bool IsEnabled { get; set; } = true;
+
+        [Description("Режим отладки")] 
+        public bool Debug { get; set; } = false;
+
+        [Description("Автоматический спавн маски в начале раунда")] 
+        public bool AutoSpawnEnabled { get; set; } = true;
+
+        [Description("Сколько масок спавнить при успешной проверке шанса")]
+        public int MasksToSpawn { get; set; } = 1;
+
+        [Description("Общий шанс, что в этом раунде маска(и) вообще появятся, %")]
+        public float RoundSpawnChancePercent { get; set; } = 60f;
+
+        [Description("Шансы спавна по зонам (в %). Суммирование не требуется, это индивидуальный шанс попытки на комнату в зоне")]
+        public Dictionary<ZoneType, float> SpawnWeights { get; set; } = new Dictionary<ZoneType, float>
+        {
+            [ZoneType.LightContainment] = 45f,
+            [ZoneType.HeavyContainment] = 30f,
+            [ZoneType.Entrance] = 20f,
+            [ZoneType.Surface] = 10f,
+        };
+
+        [Description("Показывать общую анонс-надпись при поднятии маски")] 
+        public bool AnnounceOnPickup { get; set; } = true;
+
+        [Description("Сообщения плагина")] 
+        public MessageConfig Messages { get; set; } = new MessageConfig();
+
+        [Description("Настройки HSM-хинтов")] 
+        public HintConfig Hint { get; set; } = new HintConfig();
+
+        [Description("Настройки способности SCP-035")] 
+        public AbilityConfig Ability { get; set; } = new AbilityConfig();
+
+        [Description("Шанс стать SCP-035 при поднятии маски, %")] 
+        public float BecomeChancePercent { get; set; } = 100f;
+    }
+
+    public class MessageConfig
+    {
+        [Description("Анонс при поднятии маски")] 
+        public string AnnouncePickupText { get; set; } =
+            "<color=#ba55d3>ВНИМАНИЕ:</color> <color=#d8bfd8>обнаружен носитель SCP-035.</color>";
+
+        [Description("Хинт жертве, которую задело АОЕ. {damage} будет заменён на число урона")] 
+        public string VictimHitText { get; set; } =
+            "<color=#ff6a6a>Вы поражены ядовитой речью SCP-035 (-{damage} HP)</color>";
+
+        [Description("Хинт носителю, если успешно задело кого-то. {count} заменится на число целей")] 
+        public string AbilityUsedText { get; set; } =
+            "<color=#7fffd4>Вы задели целей: {count}</color>";
+
+        [Description("Сообщение игроку, если маска отказалась присоединиться")] 
+        public string DenyPickupText { get; set; } =
+            "<color=#aaa>Маска холодно шепчет: 'Не тебя я ищу...'</color>";
+    }
+
+    public class HintConfig
+    {
+        [Description("Размер текста (10-30)")] 
+        public int TextSize { get; set; } = 20;
+
+        [Description("Позиция по X (-100 - 100)")] 
+        public int XPosition { get; set; } = 0;
+
+        [Description("Позиция по Y (-100 - 100)")] 
+        public int YPosition { get; set; } = 50;
+    }
+
+    public class AbilityConfig
+    {
+        [Description("Радиус действия способности (метры)")] 
+        public float Radius { get; set; } = 8f;
+
+        [Description("Минимальный урон способности")] 
+        public int MinDamage { get; set; } = 10;
+
+        [Description("Максимальный урон способности")] 
+        public int MaxDamage { get; set; } = 25;
+
+        [Description("Кулдаун способности (сек)")] 
+        public float CooldownSeconds { get; set; } = 25f;
+
+        [Description("Может ли способность задевать SCP")] 
+        public bool CanAffectScps { get; set; } = false;
+
+        [Description("Шанс успешного применения по каждой цели, %")] 
+        public float SuccessPercent { get; set; } = 100f;
+    }
+}

--- a/SCP035/Plugin.cs
+++ b/SCP035/Plugin.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using CommandSystem;
+using Exiled.API.Enums;
+using Exiled.API.Extensions;
+using Exiled.API.Features;
+using Exiled.API.Features.Items;
+using Exiled.API.Features.Pickups;
+using Exiled.API.Interfaces;
+using Exiled.Events.EventArgs.Player;
+using Exiled.Events.EventArgs.Server;
+using Exiled.Permissions.Extensions;
+using MEC;
+using PlayerRoles;
+using UnityEngine;
+using Hint = HintServiceMeow.Core.Models.Hints.Hint;
+using HintServiceMeow.Core.Enum;
+using HintServiceMeow.Core.Utilities;
+
+namespace SCP035
+{
+    public class Plugin : Plugin<Config>
+    {
+        public override string Name => "SCP-035";
+        public override string Author => "SteamTime & GPT";
+        public override Version Version => new Version(1, 0, 0);
+        public string[] RequiredPermissions { get; } = new[] { "scp035.admin" };
+
+        public static Plugin Instance;
+
+        private readonly System.Random random = new System.Random();
+
+        // Активные носители SCP-035
+        private readonly Dictionary<Player, Scp035State> scp035Players = new Dictionary<Player, Scp035State>();
+
+        // Активные HSM-хинты для игроков
+        private readonly Dictionary<Player, Hint> activeHints = new Dictionary<Player, Hint>();
+
+        // Заспавненные маски на карте
+        public readonly List<Pickup> spawnedMasks = new List<Pickup>();
+
+        public override void OnEnabled()
+        {
+            Instance = this;
+
+            Exiled.Events.Handlers.Server.RoundStarted += OnRoundStarted;
+            Exiled.Events.Handlers.Server.RoundEnded += OnRoundEnded;
+            Exiled.Events.Handlers.Player.Destroying += OnPlayerDestroying;
+            Exiled.Events.Handlers.Player.PickingUpItem += OnPickingUpItem;
+            Exiled.Events.Handlers.Player.DroppingItem += OnDroppingItem;
+            Exiled.Events.Handlers.Player.Died += OnPlayerDied;
+            Exiled.Events.Handlers.Player.ChangingRole += OnChangingRole;
+
+            if (Config.AutoSpawnEnabled)
+                TrySpawnMasksAtRoundStart();
+
+            Log.Info("SCP-035 загружен. Маска ждёт нового носителя...");
+            base.OnEnabled();
+        }
+
+        public override void OnDisabled()
+        {
+            Exiled.Events.Handlers.Server.RoundStarted -= OnRoundStarted;
+            Exiled.Events.Handlers.Server.RoundEnded -= OnRoundEnded;
+            Exiled.Events.Handlers.Player.Destroying -= OnPlayerDestroying;
+            Exiled.Events.Handlers.Player.PickingUpItem -= OnPickingUpItem;
+            Exiled.Events.Handlers.Player.DroppingItem -= OnDroppingItem;
+            Exiled.Events.Handlers.Player.Died -= OnPlayerDied;
+            Exiled.Events.Handlers.Player.ChangingRole -= OnChangingRole;
+
+            foreach (var hint in activeHints.Values)
+                hint.Hide = true;
+            activeHints.Clear();
+
+            CleanupMasks();
+            scp035Players.Clear();
+            Instance = null;
+            Log.Info("SCP-035 выгружен.");
+            base.OnDisabled();
+        }
+
+        private void OnRoundStarted()
+        {
+            scp035Players.Clear();
+            CleanupMasks();
+            if (Config.AutoSpawnEnabled)
+                TrySpawnMasksAtRoundStart();
+
+            if (Config.Debug)
+                Log.Debug("Раунд начался. Проверка шанса и спавн маски(масок).");
+        }
+
+        private void OnRoundEnded(RoundEndedEventArgs ev)
+        {
+            CleanupMasks();
+            foreach (var hint in activeHints.Values)
+                hint.Hide = true;
+            activeHints.Clear();
+            scp035Players.Clear();
+        }
+
+        private void OnPlayerDestroying(DestroyingEventArgs ev)
+        {
+            HideHint(ev.Player);
+            scp035Players.Remove(ev.Player);
+        }
+
+        private void OnChangingRole(ChangingRoleEventArgs ev)
+        {
+            // Если игрок меняет роль (ре-спавн и т.п.) — снимаем статус 035
+            if (scp035Players.ContainsKey(ev.Player))
+            {
+                scp035Players.Remove(ev.Player);
+                HideHint(ev.Player);
+            }
+        }
+
+        private void OnPlayerDied(DiedEventArgs ev)
+        {
+            if (ev.Player == null)
+                return;
+
+            // Если умер носитель 035 — маска падает на землю
+            if (scp035Players.ContainsKey(ev.Player))
+            {
+                scp035Players.Remove(ev.Player);
+                HideHint(ev.Player);
+
+                TryDropMask(ev.Player.Position);
+
+                if (Config.Debug)
+                    Log.Debug($"Носитель SCP-035 умер. Маска упала в {ev.Player.Position}.");
+            }
+        }
+
+        private void OnPickingUpItem(PickingUpItemEventArgs ev)
+        {
+            if (ev.Pickup == null)
+                return;
+
+            // Проверяем, одна ли это из наших масок
+            if (spawnedMasks.Contains(ev.Pickup) && ev.Pickup.Type == ItemType.SCP268)
+            {
+                // Проверка шанса стать SCP-035 при поднятии
+                if (random.NextDouble() * 100f <= Config.BecomeChancePercent)
+                {
+                    spawnedMasks.Remove(ev.Pickup);
+                    BecomeScp035(ev.Player);
+                }
+                else
+                {
+                    // Отказ — запрещаем подбирать, маска остаётся лежать
+                    ev.IsAllowed = false;
+                    ShowHint(ev.Player, Config.Messages.DenyPickupText, 4f);
+                }
+            }
+        }
+
+        private void OnDroppingItem(DroppingItemEventArgs ev)
+        {
+            if (!ev.IsAllowed || ev.Item == null)
+                return;
+
+            // Способность активируется попыткой выкинуть маску (SCP-268) у носителя SCP-035
+            if (ev.Item.Type == ItemType.SCP268 && scp035Players.ContainsKey(ev.Player))
+            {
+                ev.IsAllowed = false; // Не даём выбросить, вместо этого — способность
+                UseAbilityAoE(ev.Player);
+            }
+        }
+
+        public void TrySpawnMasksAtRoundStart()
+        {
+            CleanupMasks();
+
+            if (random.NextDouble() * 100 > Config.RoundSpawnChancePercent)
+            {
+                if (Config.Debug)
+                    Log.Debug("Шанс спавна маски не прошёл. В этом раунде маски может не быть.");
+                return;
+            }
+
+            for (int i = 0; i < Config.MasksToSpawn; i++)
+            {
+                Timing.CallDelayed(0.5f * i, () =>
+                {
+                    if (TryFindSpawnPosition(out Vector3 position))
+                    {
+                        var maskItem = Item.Create(ItemType.SCP268);
+                        var pickup = maskItem.CreatePickup(position);
+                        spawnedMasks.Add(pickup);
+
+                        if (Config.Debug)
+                            Log.Debug($"Заспавнена маска SCP-035 в {position}.");
+                    }
+                });
+            }
+        }
+
+        private void TryDropMask(Vector3 position)
+        {
+            var item = Item.Create(ItemType.SCP268);
+            var pickup = item.CreatePickup(position);
+            spawnedMasks.Add(pickup);
+        }
+
+        private void CleanupMasks()
+        {
+            foreach (var m in spawnedMasks.ToList())
+            {
+                try
+                {
+                    if (m != null && m.IsSpawned)
+                        m.Destroy();
+                }
+                catch (Exception ex)
+                {
+                    if (Config.Debug)
+                        Log.Debug($"Ошибка удаления маски: {ex}");
+                }
+            }
+            spawnedMasks.Clear();
+        }
+
+        private bool TryFindSpawnPosition(out Vector3 position)
+        {
+            position = Vector3.zero;
+
+            foreach (var room in Room.List.OrderBy(r => random.Next()))
+            {
+                if (room == null)
+                    continue;
+
+                if (Config.SpawnWeights.TryGetValue(room.Zone, out float weight) && random.NextDouble() * 100 < weight)
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        Vector3 testPos = room.Position + new Vector3(
+                            (float)(random.NextDouble() * 6 - 3),
+                            1.2f,
+                            (float)(random.NextDouble() * 6 - 3));
+
+                        if (IsValidSpawnPosition(testPos))
+                        {
+                            position = testPos;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsValidSpawnPosition(Vector3 position)
+        {
+            return !Physics.CheckSphere(position, 0.5f, LayerMask.GetMask("Default", "Player", "Ragdoll")) &&
+                   position.y > -10f;
+        }
+
+        private void BecomeScp035(Player player)
+        {
+            if (player == null || !player.IsAlive)
+                return;
+
+            if (scp035Players.ContainsKey(player))
+            {
+                ShowHint(player, "<color=yellow>Вы уже являетесь носителем SCP-035.</color>", 4f);
+                return;
+            }
+
+            // Выдаём носителю маску в инвентарь, если её нет
+            if (!player.Items.Any(i => i.Type == ItemType.SCP268))
+                player.AddItem(ItemType.SCP268);
+
+            var state = new Scp035State
+            {
+                AbilityReadyTime = Time.time + Config.Ability.CooldownSeconds,
+            };
+            scp035Players[player] = state;
+
+            if (Config.AnnounceOnPickup)
+            {
+                Map.Broadcast(6, Config.Messages.AnnouncePickupText);
+            }
+
+            ShowHint(player,
+                $"<color=#ba55d3>Вы надели Маску SCP-035.</color>\n" +
+                $"<color=#d8bfd8>Активируйте способность: попытайтесь выкинуть маску (G) — сработает АОЕ-атака.</color>\n" +
+                $"<color=#87cefa>Радиус: {Config.Ability.Radius}м | Урон: {Config.Ability.MinDamage}-{Config.Ability.MaxDamage} | КД: {Config.Ability.CooldownSeconds}с</color>", 8f);
+        }
+
+        private void UseAbilityAoE(Player user)
+        {
+            if (!scp035Players.TryGetValue(user, out var state))
+                return;
+
+            float now = Time.time;
+            if (now < state.AbilityReadyTime)
+            {
+                float left = state.AbilityReadyTime - now;
+                ShowHint(user, $"<color=yellow>Способность на перезарядке: {left:0.0}с</color>", 2.5f);
+                return;
+            }
+
+            int affected = 0;
+            foreach (var target in Player.List.ToList())
+            {
+                if (target == null || !target.IsAlive || target == user)
+                    continue;
+
+                if (!Config.Ability.CanAffectScps && target.IsScp)
+                    continue;
+
+                // Проверяем дистанцию
+                if (Vector3.Distance(user.Position, target.Position) > Config.Ability.Radius)
+                    continue;
+
+                // Простая проверка LOS — рейкаст вниз сверху над целью, чтобы реже бить сквозь стены
+                // (упрощённо, чтобы избежать дорогого Raycast между игроками)
+                var head = target.Position + Vector3.up * 1.2f;
+                if (Physics.Raycast(head + Vector3.up * 0.2f, Vector3.down, out RaycastHit hit, 2f))
+                {
+                    // Шанс на успех по цели (можно настроить в конфиге)
+                    if (random.NextDouble() * 100 <= Config.Ability.SuccessPercent)
+                    {
+                        int damage = random.Next(Config.Ability.MinDamage, Config.Ability.MaxDamage + 1);
+                        target.Hurt(damage, "SCP-035: Токсичный психоз");
+                        ShowHint(target, Config.Messages.VictimHitText.Replace("{damage}", damage.ToString()), 3.5f);
+                        affected++;
+                    }
+                }
+            }
+
+            if (affected > 0)
+            {
+                ShowHint(user, Config.Messages.AbilityUsedText.Replace("{count}", affected.ToString()), 3.5f);
+            }
+            else
+            {
+                ShowHint(user, "<color=#aaa>Никого не задело...</color>", 2.5f);
+            }
+
+            state.AbilityReadyTime = Time.time + Config.Ability.CooldownSeconds;
+            scp035Players[user] = state;
+        }
+
+        private void ShowHint(Player player, string message, float duration)
+        {
+            try
+            {
+                if (!activeHints.TryGetValue(player, out var hint))
+                {
+                    hint = new Hint
+                    {
+                        FontSize = Config.Hint.TextSize,
+                        XCoordinate = Config.Hint.XPosition,
+                        YCoordinate = Config.Hint.YPosition,
+                        Alignment = HintAlignment.Center,
+                        SyncSpeed = HintSyncSpeed.Fast,
+                        Hide = false
+                    };
+                    PlayerDisplay.Get(player).AddHint(hint);
+                    activeHints[player] = hint;
+                }
+
+                hint.Text = message;
+                Timing.CallDelayed(duration, () =>
+                {
+                    if (activeHints.TryGetValue(player, out var h) && h.Text == message)
+                    {
+                        h.Hide = true;
+                        activeHints.Remove(player);
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Не удалось показать подсказку: {ex}");
+            }
+        }
+
+        private void HideHint(Player player)
+        {
+            if (activeHints.TryGetValue(player, out var hint))
+            {
+                hint.Hide = true;
+                activeHints.Remove(player);
+            }
+        }
+
+        // Состояние SCP-035 на игроке
+        private struct Scp035State
+        {
+            public float AbilityReadyTime;
+        }
+    }
+}

--- a/SCP035/PluginUtils.cs
+++ b/SCP035/PluginUtils.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Exiled.API.Features;
+using Exiled.API.Enums;
+
+namespace SCP035
+{
+    public static class PluginUtils
+    {
+        public static void ForceBecome035(Player player)
+        {
+            if (player == null || !player.IsAlive)
+                return;
+
+            if (!player.Items.Any(i => i.Type == ItemType.SCP268))
+                player.AddItem(ItemType.SCP268);
+
+            var method = typeof(Plugin).GetMethod("BecomeScp035", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method?.Invoke(Plugin.Instance, new object[] { player });
+        }
+    }
+}

--- a/SCP035/README.md
+++ b/SCP035/README.md
@@ -1,0 +1,84 @@
+# SCP-035 (Exiled) с HSM-хинтами
+
+Кастомная роль/состояние SCP-035 (Маска): в раунде может заспавниться одна или несколько масок (типа SCP-268). Подняв маску, игрок становится носителем SCP-035 и получает способность АОЕ-атаки «токсичной речи». Все визуальные подсказки сделаны через HintServiceMeow (HSM).
+
+## Возможности
+- Автоспавн масок по зонам с весами и общим шансом на раунд
+- Настраиваемый шанс стать SCP-035 при поднятии маски
+- Способность носителя: АОЕ-урон по игрокам рядом с кулдауном и шансом успешного применения
+- Падение маски на землю при смерти носителя
+- Хинты HSM: настраиваемые позиции/размер
+- Команды для админов
+
+## Требования
+- EXILED последней версии под ваш билд сервера
+- HintServiceMeow (HSM)
+
+## Установка
+1. Скомпилировать проект и поместить DLL в `Exiled/Plugins`.
+2. Убедиться, что HSM установлен и активирован.
+3. Запустить сервер, после первого старта появится конфиг.
+
+## Команды (RA/GC)
+- `scp035 info` — информация о количестве активных масок на карте
+- `scp035 give <userid>` — выдать маску игроку
+- `scp035 set <userid>` — принудительно сделать игрока носителем 035
+- `scp035 respawn` — переспавнить маски по текущей конфигурации
+- `scp035 map` — показать распределение масок по зонам
+
+Право: `scp035.admin`
+
+## Конфиг (пример)
+```yml
+SCP035:
+  IsEnabled: true
+  Debug: false
+  AutoSpawnEnabled: true
+  MasksToSpawn: 1
+  RoundSpawnChancePercent: 60
+  BecomeChancePercent: 100
+  SpawnWeights:
+    LightContainment: 45
+    HeavyContainment: 30
+    Entrance: 20
+    Surface: 10
+
+  AnnounceOnPickup: true
+  Messages:
+    AnnouncePickupText: "<color=#ba55d3>ВНИМАНИЕ:</color> <color=#d8bfd8>обнаружен носитель SCP-035.</color>"
+    VictimHitText: "<color=#ff6a6a>Вы поражены ядовитой речью SCP-035 (-{damage} HP)</color>"
+    AbilityUsedText: "<color=#7fffd4>Вы задели целей: {count}</color>"
+    DenyPickupText: "<color=#aaa>Маска холодно шепчет: 'Не тебя я ищу...'</color>"
+
+  Hint:
+    TextSize: 20
+    XPosition: 0
+    YPosition: 50
+
+  Ability:
+    Radius: 8
+    MinDamage: 10
+    MaxDamage: 25
+    CooldownSeconds: 25
+    CanAffectScps: false
+    SuccessPercent: 100
+```
+
+## Как это работает (кратко)
+- В начале раунда по шансу `RoundSpawnChancePercent` спавнятся `MasksToSpawn` масок. Точки выбираются случайно по комнатам, шанс на комнату берётся из `SpawnWeights` по зоне.
+- Игрок, подобравший маску, с шансом `BecomeChancePercent` становится носителем SCP-035. Если шанс не прошёл — маска «отказывает» и появляется снова рядом.
+- У носителя попытка выбросить SCP-268 (G) триггерит способность: в радиусе `Radius` всем целям (кроме SCP, если `CanAffectScps=false`) с вероятностью `SuccessPercent` наносится урон от `MinDamage` до `MaxDamage`. Кулдаун — `CooldownSeconds`.
+- При смерти носителя маска падает на землю.
+
+## Примечания по HSM
+Плагин использует HSM API: при показе хинта создаётся объект Hint с параметрами из блока `Hint` и добавляется через `PlayerDisplay.Get(player).AddHint(hint)`. Хинты скрываются по таймеру.
+
+## Изменение баланса
+- Увеличить/уменьшить количество масок — `MasksToSpawn`
+- Сделать 035 реже — уменьшить `BecomeChancePercent`
+- Смягчить/усилить способность — `Radius`, `MinDamage`, `MaxDamage`, `CooldownSeconds`, `SuccessPercent`
+
+## Советы
+- Если хотите, чтобы маска редко появлялась, снизьте `RoundSpawnChancePercent`.
+- В зонах задавайте веса так, чтобы предмет чаще появлялся в LCZ.
+```


### PR DESCRIPTION
Adds a new Exiled plugin to introduce a custom SCP-035 role with configurable abilities and HSM hint integration.

This plugin allows players to become SCP-035 by interacting with a spawned mask, gaining a unique AOE ability, with all aspects (spawn rates, ability stats, messages) fully customizable via config.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f0ed0bd-635e-4664-bd59-618269996350">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f0ed0bd-635e-4664-bd59-618269996350">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

