### PR TITLE
Плагин для маски 096 и биндов

### DIFF
--- a/Scp096Mask/Config.cs
+++ b/Scp096Mask/Config.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Exiled.API.Enums;
+using Exiled.API.Interfaces;
+
+namespace Scp096Mask
+{
+    public class Config : IConfig
+    {
+        [Description("Включен ли плагин")] 
+        public bool IsEnabled { get; set; } = true;
+
+        [Description("Режим отладки")] 
+        public bool Debug { get; set; } = false;
+
+        [Description("Автоматический спавн масок на карте")] 
+        public bool AutoSpawnEnabled { get; set; } = true;
+
+        [Description("Количество масок для спавна")] 
+        public int MasksToSpawn { get; set; } = 6;
+
+        [Description("Шансы спавна по зонам (в %)")] 
+        public Dictionary<ZoneType, float> SpawnWeights { get; set; } = new()
+        {
+            [ZoneType.LightContainment] = 40f,
+            [ZoneType.HeavyContainment] = 30f,
+            [ZoneType.Entrance] = 20f,
+            [ZoneType.Surface] = 10f,
+        };
+
+        [Description("Максимум попыток поиска валидной точки спавна на одну маску")] 
+        public int MaxSpawnTriesPerMask { get; set; } = 12;
+
+        [Description("Настройки отображения подсказок через HSM")] 
+        public HintSettings HintSettings { get; set; } = new();
+
+        [Description("Сообщение при поднятии маски")] 
+        public string PickupMaskMessage { get; set; } = "<color=yellow>Вы нашли <b>Маску SCP-096</b>! Держите её в руках и используйте привязку, чтобы надеть её на 096.</color>";
+
+        [Description("Сообщение, когда игрок не держит маску в руках")] 
+        public string NeedMaskInHandsMessage { get; set; } = "<color=orange>Возьмите маску в руки (это аптечка, выданная этим плагином).</color>";
+
+        [Description("Сообщение, когда рядом нет 096 или вы на него не смотрите")] 
+        public string NeedLookAt096Message { get; set; } = "<color=orange>Подойдите к SCP-096, посмотрите на него и затем активируйте привязку.</color>";
+
+        [Description("Сообщение при успешной установке маски")] 
+        public string MaskEquippedMessage { get; set; } = "<color=green>Маска установлена на SCP-096. Он больше не агрится от взгляда.</color>";
+
+        [Description("Сообщение при отмене установки маски")] 
+        public string MaskEquipCancelledMessage { get; set; } = "<color=red>Установка маски прервана.</color>";
+
+        [Description("Сообщение, если на 096 уже надета маска")] 
+        public string MaskAlreadyOnMessage { get; set; } = "<color=#aaaaaa>На SCP-096 уже надета маска.</color>";
+
+        [Description("Максимальная дистанция до 096 для начала установки маски (в метрах)")] 
+        public float EquipMaxDistance { get; set; } = 2.2f;
+
+        [Description("Максимальный угол отклонения взгляда от направления к 096 (в градусах)")] 
+        public float EquipMaxAngleDeg { get; set; } = 20f;
+
+        [Description("Время установки маски (сек)")] 
+        public float EquipTimeSeconds { get; set; } = 3.0f;
+
+        [Description("Текст заголовка прогресса установки")] 
+        public string EquipProgressTitle { get; set; } = "Установка маски на SCP-096";
+
+        [Description("Разрешить использовать маску как обычную аптечку (должно быть false)")] 
+        public bool AllowMaskAsMedkit { get; set; } = false;
+
+        [Description("Текст категории настроек ServerSpecificSettings")] 
+        public string SettingHeaderLabel { get; set; } = "Scp096Mask";
+
+        [Description("ID бинда для ServerSpecificSettings")] 
+        public int KeybindId { get; set; } = 301;
+
+        [Description("Название бинда")] 
+        public string KeybindLabel { get; set; } = "Надеть маску на SCP-096";
+
+        [Description("Подсказка для бинда")] 
+        public string KeybindHint { get; set; } = "Будучи рядом и глядя на SCP-096, активируйте для начала установки маски.";
+    }
+
+    public class HintSettings
+    {
+        [Description("Размер текста (10-30)")] 
+        public int TextSize { get; set; } = 20;
+
+        [Description("Позиция по X (-100 - 100)")] 
+        public int XPosition { get; set; } = 0;
+
+        [Description("Позиция по Y (-100 - 100)")] 
+        public int YPosition { get; set; } = 50;
+    }
+}

--- a/Scp096Mask/EventHandlers.cs
+++ b/Scp096Mask/EventHandlers.cs
@@ -1,0 +1,560 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Exiled.API.Enums;
+using Exiled.API.Features;
+using Exiled.API.Features.Items;
+using Exiled.API.Features.Pickups;
+using Exiled.Events.EventArgs.Player;
+using Exiled.Events.EventArgs.Server;
+using Exiled.Events.EventArgs.Scp096;
+using MEC;
+using PlayerRoles;
+using UnityEngine;
+using Hint = HintServiceMeow.Core.Models.Hints.Hint;
+using HintServiceMeow.Core.Enum;
+using HintServiceMeow.Core.Utilities;
+using UserSettings.ServerSpecific;
+
+namespace Scp096Mask
+{
+    internal class EventHandlers
+    {
+        private readonly Config _config;
+
+        private readonly System.Random _random = new();
+
+        private readonly List<Pickup> _spawnedMaskPickups = new();
+        private readonly HashSet<ushort> _maskSerials = new();
+        private readonly HashSet<Player> _masked096 = new();
+
+        private readonly Dictionary<Player, Hint> _hints = new();
+        private readonly Dictionary<Player, CoroutineHandle> _activeEquipCoroutines = new();
+
+        internal EventHandlers(Config config)
+        {
+            _config = config;
+        }
+
+        internal void RegisterEvents()
+        {
+            Exiled.Events.Handlers.Server.RoundStarted += OnRoundStarted;
+            Exiled.Events.Handlers.Server.RoundEnded += OnRoundEnded;
+            Exiled.Events.Handlers.Server.RestartingRound += OnRestartingRound;
+
+            Exiled.Events.Handlers.Player.PickingUpItem += OnPickingUpItem;
+            Exiled.Events.Handlers.Player.UsingItem += OnUsingItem;
+            Exiled.Events.Handlers.Player.DroppedItem += OnDroppedItem;
+            Exiled.Events.Handlers.Player.Destroying += OnPlayerDestroying;
+            Exiled.Events.Handlers.Player.ChangingRole += OnChangingRole;
+            Exiled.Events.Handlers.Player.Verified += OnVerified;
+
+            ServerSpecificSettingsSync.ServerOnSettingValueReceived += OnSettingValueReceived;
+
+            Exiled.Events.Handlers.Scp096.AddingTarget += OnScp096AddingTarget;
+        }
+
+        internal void UnregisterEvents()
+        {
+            Exiled.Events.Handlers.Server.RoundStarted -= OnRoundStarted;
+            Exiled.Events.Handlers.Server.RoundEnded -= OnRoundEnded;
+            Exiled.Events.Handlers.Server.RestartingRound -= OnRestartingRound;
+
+            Exiled.Events.Handlers.Player.PickingUpItem -= OnPickingUpItem;
+            Exiled.Events.Handlers.Player.UsingItem -= OnUsingItem;
+            Exiled.Events.Handlers.Player.DroppedItem -= OnDroppedItem;
+            Exiled.Events.Handlers.Player.Destroying -= OnPlayerDestroying;
+            Exiled.Events.Handlers.Player.ChangingRole -= OnChangingRole;
+            Exiled.Events.Handlers.Player.Verified -= OnVerified;
+
+            ServerSpecificSettingsSync.ServerOnSettingValueReceived -= OnSettingValueReceived;
+
+            Exiled.Events.Handlers.Scp096.AddingTarget -= OnScp096AddingTarget;
+
+            foreach (var hint in _hints.Values)
+                hint.Hide = true;
+
+            _hints.Clear();
+            ClearAllMasks();
+            _maskSerials.Clear();
+            _masked096.Clear();
+
+            foreach (var kvp in _activeEquipCoroutines.ToList())
+                CancelEquipProgress(kvp.Key);
+
+            _activeEquipCoroutines.Clear();
+        }
+
+        private void OnVerified(Exiled.Events.EventArgs.Player.VerifiedEventArgs ev)
+        {
+            ServerSpecificSettingsSync.SendToPlayer(ev.Player.ReferenceHub);
+        }
+
+        private void OnRoundStarted()
+        {
+            _spawnedMaskPickups.Clear();
+            _maskSerials.Clear();
+            _masked096.Clear();
+            _activeEquipCoroutines.Clear();
+
+            if (_config.AutoSpawnEnabled)
+                SpawnMasks();
+        }
+
+        private void OnRoundEnded(RoundEndedEventArgs ev)
+        {
+            foreach (var kvp in _activeEquipCoroutines.ToList())
+                CancelEquipProgress(kvp.Key);
+
+            _activeEquipCoroutines.Clear();
+            ClearAllMasks();
+            _maskSerials.Clear();
+            _masked096.Clear();
+        }
+
+        private void OnRestartingRound()
+        {
+            foreach (var kvp in _activeEquipCoroutines.ToList())
+                CancelEquipProgress(kvp.Key);
+
+            _activeEquipCoroutines.Clear();
+            ClearAllMasks();
+            _maskSerials.Clear();
+            _masked096.Clear();
+        }
+
+        private void OnPickingUpItem(PickingUpItemEventArgs ev)
+        {
+            try
+            {
+                if (ev.Pickup == null)
+                    return;
+
+                if (_spawnedMaskPickups.Contains(ev.Pickup))
+                {
+                    _spawnedMaskPickups.Remove(ev.Pickup);
+                }
+
+                if (_maskSerials.Contains(ev.Pickup.Serial))
+                {
+                    _maskSerials.Remove(ev.Pickup.Serial);
+
+                    if (ev.Player != null && ev.Item != null)
+                    {
+                        _maskSerials.Add(ev.Item.Serial);
+                        ShowHint(ev.Player, _config.PickupMaskMessage, 5f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"OnPickingUpItem error: {ex}");
+            }
+        }
+
+        private void OnUsingItem(UsingItemEventArgs ev)
+        {
+            try
+            {
+                if (ev.Item == null)
+                    return;
+
+                if (ev.Item.Type == ItemType.Medkit && _maskSerials.Contains(ev.Item.Serial) && !_config.AllowMaskAsMedkit)
+                {
+                    ev.IsAllowed = false;
+                    ShowHint(ev.Player, _config.NeedLookAt096Message, 3f);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"OnUsingItem error: {ex}");
+            }
+        }
+
+        private void OnDroppedItem(Exiled.Events.EventArgs.Player.DroppedItemEventArgs ev)
+        {
+            try
+            {
+                if (ev.Item == null || ev.Pickup == null)
+                    return;
+
+                if (ev.Item.Type == ItemType.Medkit && _maskSerials.Contains(ev.Item.Serial))
+                {
+                    _maskSerials.Remove(ev.Item.Serial);
+                    _maskSerials.Add(ev.Pickup.Serial);
+                    if (!_spawnedMaskPickups.Contains(ev.Pickup))
+                        _spawnedMaskPickups.Add(ev.Pickup);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"OnDroppedItem error: {ex}");
+            }
+        }
+
+        private void OnPlayerDestroying(Exiled.Events.EventArgs.Player.DestroyingEventArgs ev)
+        {
+            if (_hints.TryGetValue(ev.Player, out Hint hint))
+            {
+                hint.Hide = true;
+                _hints.Remove(ev.Player);
+            }
+
+            CancelEquipProgress(ev.Player);
+
+            if (_masked096.Contains(ev.Player))
+                _masked096.Remove(ev.Player);
+        }
+
+        private void OnChangingRole(Exiled.Events.EventArgs.Player.ChangingRoleEventArgs ev)
+        {
+            CancelEquipProgress(ev.Player);
+
+            if (ev.Player == null)
+                return;
+
+            if (_masked096.Contains(ev.Player) && ev.NewRole != RoleTypeId.Scp096)
+                _masked096.Remove(ev.Player);
+        }
+
+        private void OnSettingValueReceived(ReferenceHub hub, ServerSpecificSettingBase settingBase)
+        {
+            try
+            {
+                if (!Player.TryGet(hub, out Player player))
+                    return;
+
+                if (settingBase is SSKeybindSetting key && key.SettingId == _config.KeybindId && key.SyncIsPressed)
+                {
+                    TryStartEquip(player);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"OnSettingValueReceived error: {ex}");
+            }
+        }
+
+        private void OnScp096AddingTarget(AddingTargetEventArgs ev)
+        {
+            try
+            {
+                var scp096Owner = ev.Scp096?.Owner;
+                if (scp096Owner != null && _masked096.Contains(scp096Owner))
+                {
+                    ev.IsAllowed = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"OnScp096AddingTarget error: {ex}");
+            }
+        }
+
+        private void TryStartEquip(Player player)
+        {
+            if (player == null || !player.IsAlive)
+                return;
+
+            if (_activeEquipCoroutines.ContainsKey(player))
+                return;
+
+            var currentItem = player.CurrentItem;
+            if (currentItem == null || currentItem.Type != ItemType.Medkit || !_maskSerials.Contains(currentItem.Serial))
+            {
+                ShowHint(player, _config.NeedMaskInHandsMessage, 3f);
+                return;
+            }
+
+            Player scp096 = FindLookedScp096(player, _config.EquipMaxDistance, _config.EquipMaxAngleDeg);
+            if (scp096 == null)
+            {
+                ShowHint(player, _config.NeedLookAt096Message, 3f);
+                return;
+            }
+
+            if (_masked096.Contains(scp096))
+            {
+                ShowHint(player, _config.MaskAlreadyOnMessage, 3f);
+                return;
+            }
+
+            CoroutineHandle handle = Timing.RunCoroutine(EquipMaskRoutine(player, scp096, currentItem));
+            _activeEquipCoroutines[player] = handle;
+        }
+
+        private IEnumerator<float> EquipMaskRoutine(Player installer, Player scp096, Item maskItem)
+        {
+            float time = 0f;
+            float duration = Mathf.Max(0.1f, _config.EquipTimeSeconds);
+
+            while (time < duration)
+            {
+                if (!installer.IsAlive || !scp096.IsAlive || installer.CurrentItem != maskItem)
+                {
+                    ShowHint(installer, _config.MaskEquipCancelledMessage, 2.5f);
+                    CancelEquipProgress(installer);
+                    yield break;
+                }
+
+                if (Vector3.Distance(installer.Position, scp096.Position) > _config.EquipMaxDistance)
+                {
+                    ShowHint(installer, _config.MaskEquipCancelledMessage, 2.0f);
+                    CancelEquipProgress(installer);
+                    yield break;
+                }
+
+                if (!IsLookingAt(installer, scp096, _config.EquipMaxAngleDeg))
+                {
+                    ShowHint(installer, _config.MaskEquipCancelledMessage, 2.0f);
+                    CancelEquipProgress(installer);
+                    yield break;
+                }
+
+                float progress = Mathf.Clamp01(time / duration);
+                ShowProgress(installer, _config.EquipProgressTitle, progress);
+
+                yield return Timing.WaitForSeconds(0.1f);
+                time += 0.1f;
+            }
+
+            if (!_masked096.Contains(scp096))
+                _masked096.Add(scp096);
+
+            installer.RemoveItem(maskItem);
+
+            ShowHint(installer, _config.MaskEquippedMessage, 4f);
+            ShowHint(scp096, "<color=green>На вас надели маску. Взгляд игроков больше не вызывает агрессию.</color>", 5f);
+
+            CancelEquipProgress(installer);
+        }
+
+        private void CancelEquipProgress(Player player)
+        {
+            if (_activeEquipCoroutines.TryGetValue(player, out var handle))
+            {
+                if (Timing.IsRunningCoroutine(handle))
+                    Timing.KillCoroutine(handle);
+
+                _activeEquipCoroutines.Remove(player);
+            }
+
+            if (_hints.TryGetValue(player, out var hint))
+            {
+                hint.Hide = true;
+                _hints.Remove(player);
+            }
+        }
+
+        private void SpawnMasks()
+        {
+            ClearAllMasks();
+
+            for (int i = 0; i < _config.MasksToSpawn; i++)
+            {
+                Timing.CallDelayed(0.35f * i, () =>
+                {
+                    if (TryFindSpawnPosition(out Vector3 pos))
+                    {
+                        var item = Item.Create(ItemType.Medkit);
+                        var pickup = item.CreatePickup(pos);
+
+                        _spawnedMaskPickups.Add(pickup);
+                        _maskSerials.Add(pickup.Serial);
+
+                        if (_config.Debug)
+                            Log.Debug($"Маска 096 создана в {pos}");
+                    }
+                });
+            }
+        }
+
+        private bool TryFindSpawnPosition(out Vector3 position)
+        {
+            position = Vector3.zero;
+            int tries = 0;
+
+            foreach (var room in Room.List.OrderBy(_ => _random.Next()))
+            {
+                if (_config.SpawnWeights.TryGetValue(room.Zone, out float weight))
+                {
+                    if (_random.NextDouble() * 100d > weight)
+                        continue;
+
+                    for (int i = 0; i < _config.MaxSpawnTriesPerMask; i++)
+                    {
+                        tries++;
+                        Vector3 test = room.Position + new Vector3(
+                            (float)(_random.NextDouble() * 6 - 3),
+                            1f,
+                            (float)(_random.NextDouble() * 6 - 3));
+
+                        if (IsValidSpawnPosition(test))
+                        {
+                            position = test;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsValidSpawnPosition(Vector3 position)
+        {
+            return !Physics.CheckSphere(position, 0.5f, LayerMask.GetMask("Default", "Player", "Ragdoll")) && position.y > -10f;
+        }
+
+        private void ClearAllMasks()
+        {
+            foreach (var p in _spawnedMaskPickups.ToList())
+            {
+                try
+                {
+                    if (p != null && p.IsSpawned)
+                        p.Destroy();
+                }
+                catch (Exception ex)
+                {
+                    if (_config.Debug)
+                        Log.Debug($"Ошибка удаления маски: {ex}");
+                }
+            }
+            _spawnedMaskPickups.Clear();
+        }
+
+        private Player FindLookedScp096(Player source, float maxDistance, float maxAngleDeg)
+        {
+            var scps = Player.List.Where(p => p.IsAlive && p.Role == RoleTypeId.Scp096).ToList();
+            if (scps.Count == 0)
+                return null;
+
+            Player nearest = null;
+            float nearestDist = float.MaxValue;
+
+            foreach (var scp in scps)
+            {
+                float dist = Vector3.Distance(source.Position, scp.Position);
+                if (dist > maxDistance)
+                    continue;
+
+                if (!IsLookingAt(source, scp, maxAngleDeg))
+                    continue;
+
+                if (dist < nearestDist)
+                {
+                    nearestDist = dist;
+                    nearest = scp;
+                }
+            }
+
+            return nearest;
+        }
+
+        private bool IsLookingAt(Player viewer, Player target, float maxAngleDeg)
+        {
+            try
+            {
+                Vector3 eyePos = viewer.CameraTransform.position;
+                Vector3 toTarget = (target.Position + Vector3.up * 1.2f) - eyePos;
+                Vector3 forward = viewer.CameraTransform.forward;
+
+                float angle = Vector3.Angle(forward, toTarget);
+                if (angle > maxAngleDeg)
+                    return false;
+
+                if (Physics.Linecast(eyePos, target.Position + Vector3.up * 1.2f, out RaycastHit hit, LayerMask.GetMask("Default")))
+                {
+                    var go = hit.collider.gameObject;
+                    if (go != null && go != target.GameObject)
+                        return false;
+                }
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void ShowHint(Player player, string message, float duration)
+        {
+            try
+            {
+                if (!_hints.TryGetValue(player, out var hint))
+                {
+                    hint = new Hint
+                    {
+                        FontSize = _config.HintSettings.TextSize,
+                        XCoordinate = _config.HintSettings.XPosition,
+                        YCoordinate = _config.HintSettings.YPosition,
+                        Alignment = HintAlignment.Center,
+                        SyncSpeed = HintSyncSpeed.Fast,
+                        Hide = false,
+                        Text = string.Empty,
+                    };
+                    PlayerDisplay.Get(player).AddHint(hint);
+                    _hints[player] = hint;
+                }
+
+                hint.Text = message;
+
+                Timing.CallDelayed(duration, () =>
+                {
+                    if (_hints.TryGetValue(player, out var current) && ReferenceEquals(current, hint) && current.Text == message)
+                    {
+                        current.Hide = true;
+                        _hints.Remove(player);
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"ShowHint error: {ex}");
+            }
+        }
+
+        private void ShowProgress(Player player, string title, float progress01)
+        {
+            try
+            {
+                progress01 = Mathf.Clamp01(progress01);
+                int bars = 20;
+                int filled = Mathf.RoundToInt(progress01 * bars);
+                string bar = new string('█', filled) + new string('░', Math.Max(0, bars - filled));
+                string text = $"<color=yellow><b>{title}</b></color>\n[{bar}] {(int)(progress01 * 100)}%";
+
+                if (!_hints.TryGetValue(player, out var hint))
+                {
+                    hint = new Hint
+                    {
+                        FontSize = _config.HintSettings.TextSize,
+                        XCoordinate = _config.HintSettings.XPosition,
+                        YCoordinate = _config.HintSettings.YPosition,
+                        Alignment = HintAlignment.Center,
+                        SyncSpeed = HintSyncSpeed.Fast,
+                        Hide = false,
+                        Text = string.Empty,
+                    };
+                    PlayerDisplay.Get(player).AddHint(hint);
+                    _hints[player] = hint;
+                }
+
+                hint.Text = text;
+            }
+            catch (Exception ex)
+            {
+                if (_config.Debug)
+                    Log.Debug($"ShowProgress error: {ex}");
+            }
+        }
+    }
+}

--- a/Scp096Mask/Plugin.cs
+++ b/Scp096Mask/Plugin.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using Exiled.API.Features;
+using Exiled.API.Features.Core.UserSettings;
+using Exiled.API.Interfaces;
+
+namespace Scp096Mask
+{
+    public class Plugin : Plugin<Config>
+    {
+        public override string Name => "Scp096Mask";
+        public override string Author => "SteamTime";
+        public override Version Version => new(1, 0, 0);
+        public override Version RequiredExiledVersion => new(9, 6, 1);
+
+        internal static Plugin Instance;
+        private EventHandlers _eventHandlers;
+
+        public override void OnEnabled()
+        {
+            Instance = this;
+
+            _eventHandlers = new EventHandlers(Config);
+            _eventHandlers.RegisterEvents();
+
+            HeaderSetting header = new(Config.SettingHeaderLabel);
+            IEnumerable<SettingBase> settings = new SettingBase[]
+            {
+                new KeybindSetting(Config.KeybindId, Config.KeybindLabel, default, hintDescription: Config.KeybindHint),
+            };
+
+            SettingBase.Register(settings);
+            SettingBase.SendToAll();
+
+            base.OnEnabled();
+        }
+
+        public override void OnDisabled()
+        {
+            _eventHandlers?.UnregisterEvents();
+            _eventHandlers = null;
+
+            Instance = null;
+            base.OnDisabled();
+        }
+    }
+}


### PR DESCRIPTION
Добавляет плагин "Маска SCP-096", позволяющий игрокам надевать маску на SCP-096 для предотвращения его агра от взгляда, с использованием настраиваемых биндов и HSM для интерфейса.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a2e3f66-63d4-43cb-8a81-48b34f4df99a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a2e3f66-63d4-43cb-8a81-48b34f4df99a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

