### PR TITLE
Scp096 mask mechanics and spawning

### DIFF
--- a/Scp096Mask/Commands.cs
+++ b/Scp096Mask/Commands.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using System.Text;
+using CommandSystem;
+using Exiled.API.Features;
+using Exiled.API.Features.Items;
+using Exiled.Permissions.Extensions;
+
+namespace Scp096Mask.Commands
+{
+	[CommandHandler(typeof(RemoteAdminCommandHandler))]
+	[CommandHandler(typeof(GameConsoleCommandHandler))]
+	public sealed class MaskCommands : ICommand
+	{
+		public string Command { get; } = "mask096";
+		public string[] Aliases { get; } = new[] { "mask", "scp096mask" };
+		public string Description { get; } = "Управление масками SCP-096";
+        public bool SanitizeResponse => false;
+
+		public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+		{
+			if (!sender.CheckPermission("mask096.admin"))
+			{
+				response = "У вас нет прав на использование этой команды!";
+				return false;
+			}
+
+			if (arguments.Count == 0)
+			{
+				response = "Использование:\n" +
+						  "mask096 spawn - заспавнить маски\n" +
+						  "mask096 info - информация о масках\n" +
+						  "mask096 give <userid> - выдать маску в инвентарь\n" +
+						  "mask096 givepickup <userid> - создать маску-пикап рядом с игроком\n" +
+						  "mask096 remove <userid> - снять маску с SCP-096\n" +
+						  "mask096 list - список замаскированных SCP-096";
+				return false;
+			}
+
+			switch (arguments.At(0).ToLower())
+			{
+				case "spawn":
+					return SpawnMasks(out response);
+
+				case "info":
+					return ShowMasksInfo(out response);
+
+				case "give":
+					if (arguments.Count < 2)
+					{
+						response = "Используйте: mask096 give <userid>";
+						return false;
+					}
+					return GiveMaskInventory(arguments.At(1), out response);
+
+				case "remove":
+					if (arguments.Count < 2)
+					{
+						response = "Используйте: mask096 remove <userid>";
+						return false;
+					}
+					return RemoveMask(arguments.At(1), out response);
+
+				case "list":
+					return ListMaskedScps(out response);
+
+				case "givepickup":
+					if (arguments.Count < 2)
+					{
+						response = "Используйте: mask096 givepickup <userid>";
+						return false;
+					}
+					return GivePickup(arguments.At(1), out response);
+
+				default:
+					response = "Неизвестная подкоманда. Доступно: spawn, info, give, givepickup, remove, list";
+					return false;
+			}
+		}
+
+		private bool SpawnMasks(out string response)
+		{
+			if (Plugin.Instance?._eventHandlers == null)
+			{
+				response = "Плагин не работает";
+				return false;
+			}
+
+			Plugin.Instance._eventHandlers.SpawnMasks();
+			response = $"{Plugin.Instance.Config.MasksToSpawn} масок SCP-096 заспавнено!";
+			return true;
+		}
+
+		private bool ShowMasksInfo(out string response)
+		{
+			if (Plugin.Instance?._eventHandlers == null)
+			{
+				response = "Плагин не работает";
+				return false;
+			}
+
+			var masks = Plugin.Instance._eventHandlers.spawnedMasks;
+			var sb = new StringBuilder();
+			sb.AppendLine("<color=yellow>Информация о масках SCP-096:</color>");
+			sb.AppendLine($"Заспавнено масок: {masks.Count}");
+			sb.AppendLine($"Время одевания: {Plugin.Instance.Config.MaskEquipTime} сек");
+			sb.AppendLine($"Дистанция взаимодействия: {Plugin.Instance.Config.InteractionDistance} м");
+			sb.AppendLine($"Автоспавн: {(Plugin.Instance.Config.AutoSpawnEnabled ? "да" : "нет")}");
+			response = sb.ToString();
+			return true;
+		}
+
+		private bool GiveMaskInventory(string userId, out string response)
+		{
+			Player player = Player.Get(userId);
+			if (player == null)
+			{
+				response = $"Игрок с ID {userId} не найден!";
+				return false;
+			}
+
+			if (Plugin.Instance?._eventHandlers != null &&
+				Plugin.Instance._eventHandlers.HasMask(player))
+			{
+				response = $"У игрока {player.Nickname} уже есть маска!";
+				return false;
+			}
+
+			var medkit = player.AddItem(ItemType.Medkit);
+			Plugin.Instance?._eventHandlers?.AddPlayerMask(player, medkit);
+
+			response = $"Выдана маска SCP-096 в инвентарь игроку <color=green>{player.Nickname}</color> (<color=#aaaaaa>{player.Id}</color>)";
+			return true;
+		}
+
+		private bool RemoveMask(string userId, out string response)
+		{
+			Player player = Player.Get(userId);
+			if (player == null)
+			{
+				response = $"Игрок с ID {userId} не найден!";
+				return false;
+			}
+
+			if (player.Role.Type != PlayerRoles.RoleTypeId.Scp096)
+			{
+				response = $"Игрок {player.Nickname} не является SCP-096!";
+				return false;
+			}
+
+			if (Plugin.Instance?._eventHandlers == null)
+			{
+				response = "Плагин не работает";
+				return false;
+			}
+
+			if (!Plugin.Instance._eventHandlers.IsScp096Masked(player))
+			{
+				response = $"На SCP-096 {player.Nickname} нет маски!";
+				return false;
+			}
+
+			Plugin.Instance._eventHandlers.RemoveMaskFromScp096(player);
+			response = $"Маска снята с SCP-096 <color=green>{player.Nickname}</color>";
+			return true;
+		}
+
+		private bool ListMaskedScps(out string response)
+		{
+			if (Plugin.Instance?._eventHandlers == null)
+			{
+				response = "Плагин не работает";
+				return false;
+			}
+
+			var maskedScps = Player.List
+				.Where(p => p.Role.Type == PlayerRoles.RoleTypeId.Scp096 &&
+						   Plugin.Instance._eventHandlers.IsScp096Masked(p))
+				.ToList();
+
+			if (maskedScps.Count == 0)
+			{
+				response = "Нет масок на SCP-096";
+				return true;
+			}
+
+			var sb = new StringBuilder();
+			sb.AppendLine($"<color=yellow>Маски на SCP-096 ({maskedScps.Count}):</color>");
+			foreach (var scp in maskedScps)
+				sb.AppendLine($"• <color=green>{scp.Nickname}</color> (ID: {scp.Id})");
+			response = sb.ToString();
+			return true;
+		}
+
+		private bool GivePickup(string userId, out string response)
+		{
+			Player player = Player.Get(userId);
+			if (player == null)
+			{
+				response = $"Игрок с ID {userId} не найден!";
+				return false;
+			}
+
+			var medkit = Item.Create(ItemType.Medkit);
+			var pickup = medkit.CreatePickup(player.Position);
+			Plugin.Instance?._eventHandlers?.spawnedMasks.Add(pickup);
+			try
+			{
+				pickup.Scale = Plugin.Instance.Config.MaskPickupScale;
+				pickup.Base.GetComponentInChildren<UnityEngine.MeshRenderer>()?.material?.SetColor("_Color", Plugin.Instance.Config.MaskTint);
+			}
+			catch { }
+
+			response = $"Создана маска-пикап рядом с <color=green>{player.Nickname}</color>";
+			return true;
+		}
+	}
+}

--- a/Scp096Mask/Config.cs
+++ b/Scp096Mask/Config.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Exiled.API.Enums;
+using Exiled.API.Interfaces;
+using Scp096Mask.Enums;
+using UnityEngine;
+
+namespace Scp096Mask
+{
+	public sealed class Config : IConfig
+	{
+		[Description("Включает/выключает плагин")] public bool IsEnabled { get; set; } = true;
+		[Description("Включает отладочные логи")] public bool Debug { get; set; } = false;
+
+		[Description("Время одевания маски, сек")] public float MaskEquipTime { get; set; } = 4.0f;
+		[Description("Дистанция взаимодействия с SCP-096, м")] public float InteractionDistance { get; set; } = 2.2f;
+		[Description("Требовать держать маску в руке при одевании")] public bool RequireMaskInHand { get; set; } = true;
+
+		[Description("Автоспавн масок в начале раунда")] public bool AutoSpawnEnabled { get; set; } = true;
+		[Description("Количество масок для спавна")] public int MasksToSpawn { get; set; } = 3;
+
+		[Description("Тип активации взаимодействия с маской")] public ActivationType ActivationType { get; set; } = ActivationType.ServerSpecificSettings;
+
+		// Server Specific Settings
+		[Description("ID хоткея (ServerSpecificSettings)")] public string KeybindId { get; set; } = "scp096mask_key";
+		[Description("Лейбл хоткея (ServerSpecificSettings)")] public string KeybindLabel { get; set; } = "Маска SCP-096";
+		[Description("Подсказка хоткея (ServerSpecificSettings)")] public string KeybindHint { get; set; } = "Нажмите, чтобы надеть маску на ближайшего SCP-096";
+		[Description("Заголовок настроек (ServerSpecificSettings)")] public string SettingHeaderLabel { get; set; } = "Scp096Mask";
+
+		// Спавн по зонам с весами шанса (в процентах)
+		[Description("Шансы (в %) появления маски по зонам")] public Dictionary<ZoneType, float> SpawnWeights { get; set; } = new Dictionary<ZoneType, float>
+		{
+			{ ZoneType.Surface, 15f },
+			{ ZoneType.Entrance, 35f },
+			{ ZoneType.HeavyContainment, 60f },
+			{ ZoneType.LightContainment, 65f },
+		};
+
+		// Белый список комнат. Если пуст, используется выбор по зонам. Если указан, спавн масок происходит только в этих комнатах с шансом по именам комнат
+		[Description("Включить спавн по конкретным комнатам (Override зон)")] public bool UseRoomWhitelist { get; set; } = false;
+		[Description("Вес шанса (в %) по именам комнат при UseRoomWhitelist = true")] public Dictionary<string, float> RoomSpawnChances { get; set; } = new Dictionary<string, float>
+		{
+			// { "LCZ_WC", 50f },
+			// { "HCZ_096", 80f },
+		};
+
+		// Смещение/растяжение пикапа, чтобы отличался от обычной аптечки
+		[Description("Визуальное растяжение маски (scale)")] public Vector3 MaskPickupScale { get; set; } = new Vector3(1.0f, 1.25f, 1.0f);
+		[Description("Цвет подсветки маски (RGBA 0..1)")] public Color MaskTint { get; set; } = new Color(0.9f, 0.9f, 1.0f, 1.0f);
+
+		// Настройки хинтов
+		[Description("Настройки отображения подсказок")] public HintUiSettings HintSettings { get; set; } = new HintUiSettings();
+		[Description("Тексты сообщений")] public MessagesConfig Messages { get; set; } = new MessagesConfig();
+	}
+
+	public sealed class HintUiSettings
+	{
+		[Description("Размер текста")] public int TextSize { get; set; } = 28;
+		[Description("Позиция X")] public float XPosition { get; set; } = 0;
+		[Description("Позиция Y")] public float YPosition { get; set; } = -300;
+	}
+
+	public sealed class MessagesConfig
+	{
+		[Description("Нет маски")] public string NoMask { get; set; } = "<color=orange>У вас нет маски SCP-096!</color>";
+		[Description("Маска не в руке")] public string MaskNotInHand { get; set; } = "<color=orange>Возьмите маску в руку!</color>";
+		[Description("Слишком далеко")] public string TooFarAway { get; set; } = "<color=orange>Подойдите ближе к SCP-096.</color>";
+		[Description("Уже замаскирован")] public string AlreadyMasked { get; set; } = "<color=yellow>На этом SCP-096 уже надета маска.</color>";
+		[Description("Подобрано")] public string MaskPickedUp { get; set; } = "<color=green>Вы подобрали маску SCP-096.</color>";
+		[Description("Процесс одевания")] public string MaskEquipping { get; set; } = "Одевание маски...";
+		[Description("Маска надета")] public string MaskEquipped { get; set; } = "<color=green>Маска успешно надета!</color>";
+		[Description("Маска снята")] public string MaskRemoved { get; set; } = "<color=yellow>Маска снята.</color>";
+	}
+}

--- a/Scp096Mask/Enums/ActivationType.cs
+++ b/Scp096Mask/Enums/ActivationType.cs
@@ -1,0 +1,8 @@
+namespace Scp096Mask.Enums
+{
+	public enum ActivationType
+	{
+		ServerSpecificSettings = 0,
+		NoClip = 1,
+	}
+}

--- a/Scp096Mask/EventHandlers.cs
+++ b/Scp096Mask/EventHandlers.cs
@@ -1,0 +1,546 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Exiled.API.Enums;
+using Exiled.API.Features;
+using Exiled.API.Features.Items;
+using Exiled.API.Features.Pickups;
+using Exiled.Events.EventArgs.Player;
+using Exiled.Events.EventArgs.Server;
+using MEC;
+using PlayerRoles;
+using UnityEngine;
+using UserSettings.ServerSpecific;
+using Scp096Mask.Enums;
+using Hint = HintServiceMeow.Core.Models.Hints.Hint;
+using HintServiceMeow.Core.Enum;
+using HintServiceMeow.Core.Utilities;
+
+namespace Scp096Mask
+{
+	internal sealed class EventHandlers
+	{
+		private readonly Config _config;
+		private readonly System.Random _random = new System.Random();
+
+		public readonly List<Pickup> spawnedMasks = new List<Pickup>();
+		private readonly Dictionary<Player, Item> playersWithMasks = new Dictionary<Player, Item>();
+		private readonly HashSet<Player> maskedScp096s = new HashSet<Player>();
+		private readonly Dictionary<Player, CoroutineHandle> equipProcesses = new Dictionary<Player, CoroutineHandle>();
+		private readonly Dictionary<Player, Hint> playerHints = new Dictionary<Player, Hint>();
+
+		internal EventHandlers(Config config)
+		{
+			_config = config;
+		}
+
+		internal void RegisterEvents()
+		{
+			Exiled.Events.Handlers.Server.RoundStarted += OnRoundStarted;
+			Exiled.Events.Handlers.Server.RoundEnded += OnRoundEnded;
+			Exiled.Events.Handlers.Player.PickingUpItem += OnPickingUpItem;
+			Exiled.Events.Handlers.Player.ChangingRole += OnChangingRole;
+			Exiled.Events.Handlers.Player.Destroying += OnPlayerLeave;
+			Exiled.Events.Handlers.Player.Left += OnPlayerLeft;
+			Exiled.Events.Handlers.Player.DroppingItem += OnDroppingItem;
+			Exiled.Events.Handlers.Player.DroppedItem += OnDroppedItem;
+
+			switch (_config.ActivationType)
+			{
+				case ActivationType.ServerSpecificSettings:
+					ServerSpecificSettingsSync.ServerOnSettingValueReceived += OnSettingValueReceived;
+					Exiled.Events.Handlers.Player.Verified += OnVerified;
+					break;
+				case ActivationType.NoClip:
+					Exiled.Events.Handlers.Player.TogglingNoClip += OnTogglingNoClip;
+					break;
+			}
+		}
+
+		internal void UnregisterEvents()
+		{
+			Exiled.Events.Handlers.Server.RoundStarted -= OnRoundStarted;
+			Exiled.Events.Handlers.Server.RoundEnded -= OnRoundEnded;
+			Exiled.Events.Handlers.Player.PickingUpItem -= OnPickingUpItem;
+			Exiled.Events.Handlers.Player.ChangingRole -= OnChangingRole;
+			Exiled.Events.Handlers.Player.Destroying -= OnPlayerLeave;
+			Exiled.Events.Handlers.Player.Left -= OnPlayerLeft;
+			Exiled.Events.Handlers.Player.DroppingItem -= OnDroppingItem;
+			Exiled.Events.Handlers.Player.DroppedItem -= OnDroppedItem;
+
+			switch (_config.ActivationType)
+			{
+				case ActivationType.ServerSpecificSettings:
+					ServerSpecificSettingsSync.ServerOnSettingValueReceived -= OnSettingValueReceived;
+					Exiled.Events.Handlers.Player.Verified -= OnVerified;
+					break;
+				case ActivationType.NoClip:
+					Exiled.Events.Handlers.Player.TogglingNoClip -= OnTogglingNoClip;
+					break;
+			}
+		}
+
+		private void OnRoundStarted()
+		{
+			spawnedMasks.Clear();
+			playersWithMasks.Clear();
+			maskedScp096s.Clear();
+			equipProcesses.Clear();
+			playerHints.Clear();
+
+			if (_config.AutoSpawnEnabled)
+			{
+				Timing.CallDelayed(2f, SpawnMasks);
+			}
+
+			if (_config.Debug)
+				Log.Debug("Начало раунда");
+		}
+
+		private void OnRoundEnded(RoundEndedEventArgs ev)
+		{
+			ClearAllMasks();
+			playersWithMasks.Clear();
+			maskedScp096s.Clear();
+
+			foreach (var process in equipProcesses.Values)
+			{
+				if (process.IsRunning)
+					Timing.KillCoroutines(process);
+			}
+			equipProcesses.Clear();
+
+			ClearAllHints();
+		}
+
+		private void OnPickingUpItem(PickingUpItemEventArgs ev)
+		{
+			if (ev.Pickup.Type != ItemType.Medkit)
+				return;
+
+			bool isMask = spawnedMasks.Contains(ev.Pickup);
+			if (!isMask)
+				return;
+
+			if (HasMask(ev.Player))
+			{
+				ev.IsAllowed = false;
+				ShowHint(ev.Player, "<color=orange>У вас уже есть маска SCP-096!</color>", 3f);
+				return;
+			}
+
+			spawnedMasks.Remove(ev.Pickup);
+
+			Timing.CallDelayed(0.1f, () =>
+			{
+				var medkitItem = ev.Player.Items.FirstOrDefault(item => item.Type == ItemType.Medkit);
+				if (medkitItem != null)
+					playersWithMasks[ev.Player] = medkitItem;
+			});
+
+			ShowHint(ev.Player, _config.Messages.MaskPickedUp, 6f);
+
+			if (_config.Debug)
+				Log.Debug($"Игрок {ev.Player.Nickname} подобрал маску SCP-096");
+		}
+
+		private void OnDroppingItem(DroppingItemEventArgs ev)
+		{
+			if (ev.Item.Type != ItemType.Medkit)
+				return;
+
+			if (playersWithMasks.TryGetValue(ev.Player, out var maskItem) && maskItem == ev.Item)
+			{
+				if (equipProcesses.TryGetValue(ev.Player, out var process))
+				{
+					if (process.IsRunning)
+						Timing.KillCoroutines(process);
+					equipProcesses.Remove(ev.Player);
+					ShowHint(ev.Player, "<color=red>Процесс одевания маски прерван - вы выбросили маску!</color>", 3f);
+				}
+			}
+		}
+
+		private void OnDroppedItem(DroppedItemEventArgs ev)
+		{
+			if (ev.Item.Type != ItemType.Medkit)
+				return;
+
+			// Если это была именно наша маска, стилизуем пикап и учитываем его как маску на земле
+			if (playersWithMasks.TryGetValue(ev.Player, out var maskItem) && maskItem == ev.Item)
+			{
+				playersWithMasks.Remove(ev.Player);
+				if (ev.Pickup != null)
+				{
+					TryStyleMaskPickup(ev.Pickup);
+					spawnedMasks.Add(ev.Pickup);
+				}
+			}
+		}
+
+		private void OnChangingRole(ChangingRoleEventArgs ev)
+		{
+			playersWithMasks.Remove(ev.Player);
+			maskedScp096s.Remove(ev.Player);
+
+			if (equipProcesses.TryGetValue(ev.Player, out var process))
+			{
+				if (process.IsRunning)
+					Timing.KillCoroutines(process);
+				equipProcesses.Remove(ev.Player);
+			}
+
+			ClearPlayerHint(ev.Player);
+		}
+
+		private void OnPlayerLeave(DestroyingEventArgs ev)
+		{
+			CleanupPlayer(ev.Player);
+		}
+
+		private void OnPlayerLeft(LeftEventArgs ev)
+		{
+			CleanupPlayer(ev.Player);
+		}
+
+		private void CleanupPlayer(Player player)
+		{
+			playersWithMasks.Remove(player);
+			maskedScp096s.Remove(player);
+
+			if (equipProcesses.TryGetValue(player, out var process))
+			{
+				if (process.IsRunning)
+					Timing.KillCoroutines(process);
+				equipProcesses.Remove(player);
+			}
+
+			ClearPlayerHint(player);
+		}
+
+		private void OnVerified(VerifiedEventArgs ev)
+		{
+			if (_config.ActivationType != ActivationType.ServerSpecificSettings)
+				return;
+
+			try
+			{
+				ServerSpecificSettingsSync.SendToPlayer(ev.Player.ReferenceHub);
+			}
+			catch (Exception ex)
+			{
+				if (_config.Debug)
+					Log.Debug($"Ошибка отправки настроек игроку {ev.Player.Nickname}: {ex}");
+			}
+		}
+
+		private void OnSettingValueReceived(ReferenceHub hub, ServerSpecificSettingBase settingBase)
+		{
+			if (!Player.TryGet(hub, out Player player))
+				return;
+
+			if (settingBase is SSKeybindSetting keybindSetting &&
+				keybindSetting.SettingId == _config.KeybindId &&
+				keybindSetting.SyncIsPressed)
+			{
+				TryInteractWithScp096(player);
+			}
+		}
+
+		private void OnTogglingNoClip(TogglingNoClipEventArgs ev)
+		{
+			if (!HasMask(ev.Player))
+				return;
+
+			TryInteractWithScp096(ev.Player);
+			ev.IsAllowed = false;
+		}
+
+		private void TryInteractWithScp096(Player player)
+		{
+			if (!HasMask(player))
+			{
+				ShowHint(player, _config.Messages.NoMask, 3f);
+				return;
+			}
+
+			if (_config.RequireMaskInHand)
+			{
+				if (!playersWithMasks.TryGetValue(player, out var maskItem) || player.CurrentItem != maskItem)
+				{
+					ShowHint(player, _config.Messages.MaskNotInHand, 3f);
+					return;
+				}
+			}
+
+			if (equipProcesses.ContainsKey(player))
+			{
+				ShowHint(player, "<color=orange>Вы уже одеваете маску!</color>", 3f);
+				return;
+			}
+
+			Player nearestScp096 = null;
+			float nearestDistance = float.MaxValue;
+
+			foreach (var scp in Player.List.Where(p => p.Role.Type == RoleTypeId.Scp096))
+			{
+				float distance = Vector3.Distance(player.Position, scp.Position);
+				if (distance < nearestDistance && distance <= _config.InteractionDistance)
+				{
+					nearestDistance = distance;
+					nearestScp096 = scp;
+				}
+			}
+
+			if (nearestScp096 == null)
+			{
+				ShowHint(player, _config.Messages.TooFarAway, 3f);
+				return;
+			}
+
+			if (maskedScp096s.Contains(nearestScp096))
+			{
+				ShowHint(player, _config.Messages.AlreadyMasked, 3f);
+				return;
+			}
+
+			var equipProcess = Timing.RunCoroutine(EquipMaskProcess(player, nearestScp096));
+			equipProcesses[player] = equipProcess;
+		}
+
+		private IEnumerator<float> EquipMaskProcess(Player player, Player scp096)
+		{
+			float equipTime = _config.MaskEquipTime;
+			float elapsed = 0f;
+
+			ShowHint(player, _config.Messages.MaskEquipping, equipTime + 1f);
+
+			while (elapsed < equipTime)
+			{
+				if (player == null || !player.IsConnected || !player.IsAlive ||
+					scp096 == null || !scp096.IsConnected || !scp096.IsAlive ||
+					Vector3.Distance(player.Position, scp096.Position) > _config.InteractionDistance)
+				{
+					ShowHint(player, "<color=red>Процесс прерван!</color>", 3f);
+					equipProcesses.Remove(player);
+					yield break;
+				}
+
+				if (_config.RequireMaskInHand)
+				{
+					if (!playersWithMasks.TryGetValue(player, out var maskItem) || player.CurrentItem != maskItem)
+					{
+						ShowHint(player, "<color=red>Процесс прерван - маска не в руке!</color>", 3f);
+						equipProcesses.Remove(player);
+						yield break;
+					}
+				}
+
+				float progress = elapsed / equipTime;
+				int progressBars = Mathf.RoundToInt(progress * 10);
+				string progressBar = $"<color=yellow>[{"█".PadRight(progressBars, '█')}{"░".PadRight(10 - progressBars, '░')}] {(progress * 100):F0}%</color>";
+
+				ShowHint(player, $"{_config.Messages.MaskEquipping}\n{progressBar}", 0.5f);
+
+				elapsed += 0.2f;
+				yield return Timing.WaitForSeconds(0.2f);
+			}
+
+			if (playersWithMasks.TryGetValue(player, out var finalMaskItem))
+			{
+				player.RemoveItem(finalMaskItem);
+				playersWithMasks.Remove(player);
+			}
+
+			maskedScp096s.Add(scp096);
+			equipProcesses.Remove(player);
+
+			ShowHint(player, _config.Messages.MaskEquipped, 5f);
+			ShowHint(scp096, "<color=green>На вас надели маску!</color>", 5f);
+
+			if (_config.Debug)
+				Log.Debug($"Игрок {player.Nickname} успешно надел маску на SCP-096 {scp096.Nickname}");
+		}
+
+		public void SpawnMasks()
+		{
+			ClearAllMasks();
+
+			for (int i = 0; i < _config.MasksToSpawn; i++)
+			{
+				Timing.CallDelayed(0.3f * i, () =>
+				{
+					if (TryFindSpawnPosition(out Vector3 position))
+					{
+						var medkit = Item.Create(ItemType.Medkit);
+						var pickup = medkit.CreatePickup(position);
+
+						TryStyleMaskPickup(pickup);
+
+						spawnedMasks.Add(pickup);
+
+						if (_config.Debug)
+							Log.Debug($"Создана маска SCP-096 в {position}");
+					}
+				});
+			}
+		}
+
+		private void TryStyleMaskPickup(Pickup pickup)
+		{
+			try
+			{
+				pickup.Scale = _config.MaskPickupScale;
+				pickup.Base.transform.localScale = _config.MaskPickupScale;
+				pickup.Base.GetComponentInChildren<MeshRenderer>()?.material?.SetColor("_Color", _config.MaskTint);
+			}
+			catch
+			{
+				// ignore styling failures on some versions
+			}
+		}
+
+		private bool TryFindSpawnPosition(out Vector3 position)
+		{
+			position = Vector3.zero;
+
+			if (_config.UseRoomWhitelist && _config.RoomSpawnChances.Any())
+			{
+				var candidateRooms = Room.List
+					.Where(r => _config.RoomSpawnChances.ContainsKey(r.Name))
+					.OrderBy(_ => _random.Next())
+					.ToList();
+
+				foreach (var room in candidateRooms)
+				{
+					if (_config.RoomSpawnChances.TryGetValue(room.Name, out float chance) && _random.NextDouble() * 100 < chance)
+					{
+						if (TryRoomSample(room, out position))
+							return true;
+					}
+				}
+			}
+			else
+			{
+				var availableRooms = Room.List.Where(r => _config.SpawnWeights.ContainsKey(r.Zone)).ToList();
+				foreach (var room in availableRooms.OrderBy(_ => _random.Next()))
+				{
+					if (_config.SpawnWeights.TryGetValue(room.Zone, out float weight) && _random.NextDouble() * 100 < weight)
+					{
+						if (TryRoomSample(room, out position))
+							return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		private bool TryRoomSample(Room room, out Vector3 position)
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				Vector3 testPos = room.Position + new Vector3(
+					(float)(_random.NextDouble() * 6 - 3),
+					1f,
+					(float)(_random.NextDouble() * 6 - 3));
+
+				if (IsValidSpawnPosition(testPos))
+				{
+					position = testPos;
+					return true;
+				}
+			}
+
+			position = default;
+			return false;
+		}
+
+		private bool IsValidSpawnPosition(Vector3 pos)
+		{
+			return !Physics.CheckSphere(pos, 0.5f, LayerMask.GetMask("Default", "Player", "Ragdoll")) && pos.y > -10f;
+		}
+
+		private void ClearAllMasks()
+		{
+			foreach (var mask in spawnedMasks.ToList())
+			{
+				try
+				{
+					if (mask != null && mask.IsSpawned)
+						mask.Destroy();
+				}
+				catch (Exception ex)
+				{
+					if (_config.Debug)
+						Log.Debug($"Ошибка при удалении маски: {ex}");
+				}
+			}
+			spawnedMasks.Clear();
+		}
+
+		private void ShowHint(Player player, string message, float duration)
+		{
+			try
+			{
+				if (!playerHints.TryGetValue(player, out var hint))
+				{
+					hint = new Hint
+					{
+						FontSize = _config.HintSettings.TextSize,
+						XCoordinate = _config.HintSettings.XPosition,
+						YCoordinate = _config.HintSettings.YPosition,
+						Alignment = HintAlignment.Center,
+						SyncSpeed = HintSyncSpeed.Fast,
+						Hide = false
+					};
+					PlayerDisplay.Get(player).AddHint(hint);
+					playerHints[player] = hint;
+				}
+
+				hint.Text = message;
+				hint.Hide = false;
+
+				Timing.CallDelayed(duration, () =>
+				{
+					if (playerHints.TryGetValue(player, out var h) && h.Text == message)
+						h.Hide = true;
+				});
+			}
+			catch (Exception ex)
+			{
+				if (_config.Debug)
+					Log.Error($"Не удалось показать хинт: {ex}");
+			}
+		}
+
+		private void ClearPlayerHint(Player player)
+		{
+			if (playerHints.TryGetValue(player, out var hint))
+			{
+				hint.Hide = true;
+				playerHints.Remove(player);
+			}
+		}
+
+		private void ClearAllHints()
+		{
+			foreach (var hint in playerHints.Values)
+				hint.Hide = true;
+			playerHints.Clear();
+		}
+
+		public bool HasMask(Player player) => playersWithMasks.ContainsKey(player);
+		public void AddPlayerMask(Player player, Item maskItem) => playersWithMasks[player] = maskItem;
+		public bool IsScp096Masked(Player scp096) => maskedScp096s.Contains(scp096);
+		public void RemoveMaskFromScp096(Player scp096)
+		{
+			if (maskedScp096s.Remove(scp096))
+			{
+				ShowHint(scp096, _config.Messages.MaskRemoved, 3f);
+				if (_config.Debug)
+					Log.Debug($"Маска снята с SCP-096 {scp096.Nickname}");
+			}
+		}
+	}
+}

--- a/Scp096Mask/Patches/Scp096Patches.cs
+++ b/Scp096Mask/Patches/Scp096Patches.cs
@@ -1,0 +1,84 @@
+using System;
+using Exiled.API.Features;
+using HarmonyLib;
+using PlayerRoles.PlayableScps.Scp096;
+
+namespace Scp096Mask.Patches
+{
+	[HarmonyPatch(typeof(Scp096TargetsTracker), nameof(Scp096TargetsTracker.AddTarget))]
+	public static class Scp096AddTargetPatch
+	{
+		public static bool Prefix(Scp096TargetsTracker __instance, ReferenceHub target)
+		{
+			try
+			{
+				if (Plugin.Instance?._eventHandlers == null) return true;
+				var scp096Player = Player.Get(__instance.Owner);
+				if (scp096Player == null) return true;
+				if (Plugin.Instance._eventHandlers.IsScp096Masked(scp096Player))
+				{
+					if (Plugin.Instance.Config.Debug)
+						Log.Debug($"SCP-096 {scp096Player.Nickname} с маской не агрится на {Player.Get(target)?.Nickname}");
+					return false;
+				}
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.Error($"Ошибка в Scp096AddTargetPatch: {ex}");
+				return true;
+			}
+		}
+	}
+
+	[HarmonyPatch(typeof(Scp096TargetsTracker), nameof(Scp096TargetsTracker.IsObservedBy))]
+	public static class Scp096IsObservedByPatch
+	{
+		public static bool Prefix(Scp096TargetsTracker __instance, ReferenceHub target, ref bool __result)
+		{
+			try
+			{
+				if (Plugin.Instance?._eventHandlers == null) return true;
+				var scp096Player = Player.Get(__instance.Owner);
+				if (scp096Player == null) return true;
+				if (Plugin.Instance._eventHandlers.IsScp096Masked(scp096Player))
+				{
+					__result = false;
+					return false;
+				}
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.Error($"Ошибка в Scp096IsObservedByPatch: {ex}");
+				return true;
+			}
+		}
+	}
+
+	[HarmonyPatch(typeof(Scp096RageManager), nameof(Scp096RageManager.ServerEnrage))]
+	public static class Scp096RagePatch
+	{
+		public static bool Prefix(Scp096RageManager __instance, float duration = -1f)
+		{
+			try
+			{
+				if (Plugin.Instance?._eventHandlers == null) return true;
+				var scp096Player = Player.Get(__instance.Owner);
+				if (scp096Player == null) return true;
+				if (Plugin.Instance._eventHandlers.IsScp096Masked(scp096Player))
+				{
+					if (Plugin.Instance.Config.Debug)
+						Log.Debug($"SCP-096 {scp096Player.Nickname} с маской не может агрится");
+					return false;
+				}
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.Error($"Ошибка в Scp096RagePatch: {ex}");
+				return true;
+			}
+		}
+	}
+}

--- a/Scp096Mask/Plugin.cs
+++ b/Scp096Mask/Plugin.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Exiled.API.Features;
+using Exiled.API.Features.Core.UserSettings;
+using HarmonyLib;
+using Scp096Mask.Enums;
+
+namespace Scp096Mask
+{
+	public sealed class Plugin : Plugin<Config>
+	{
+		public override string Name => "Scp096Mask";
+		public override string Author => "SteamTime";
+		public override Version Version => new Version(1, 0, 0);
+		public override Version RequiredExiledVersion => new Version(9, 6, 1);
+
+		public static Plugin Instance;
+		internal EventHandlers _eventHandlers;
+		private Harmony _harmony;
+
+		public override void OnEnabled()
+		{
+			Instance = this;
+
+			_eventHandlers = new EventHandlers(Config);
+			_eventHandlers.RegisterEvents();
+
+			_harmony = new Harmony("Scp096Mask.Harmony");
+			_harmony.PatchAll();
+
+			if (Config.ActivationType == ActivationType.ServerSpecificSettings)
+			{
+				HeaderSetting header = new HeaderSetting(Config.SettingHeaderLabel);
+				IEnumerable<SettingBase> settingBases = new SettingBase[]
+				{
+					new KeybindSetting(Config.KeybindId, Config.KeybindLabel, default, hintDescription: Config.KeybindHint),
+				};
+				SettingBase.Register(settingBases);
+				SettingBase.SendToAll();
+			}
+
+			Log.Info("Плагин маски SCP-096 загружен!");
+			base.OnEnabled();
+		}
+
+		public override void OnDisabled()
+		{
+			_eventHandlers?.UnregisterEvents();
+			_eventHandlers = null;
+
+			try
+			{
+				_harmony?.UnpatchAll(_harmony?.Id);
+			}
+			catch (Exception)
+			{
+				// ignore
+			}
+			_harmony = null;
+
+			Instance = null;
+			Log.Info("Плагин маски SCP-096 выключен.");
+			base.OnDisabled();
+		}
+	}
+}

--- a/Scp096Mask/Properties/AssemblyInfo.cs
+++ b/Scp096Mask/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Scp096Mask")]
+[assembly: AssemblyDescription("SCP-096 mask plugin for EXILED")] 
+[assembly: AssemblyCompany("SteamTime")] 
+[assembly: AssemblyProduct("Scp096Mask")] 
+[assembly: AssemblyCopyright("Copyright © 2025")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Scp096Mask/README.md
+++ b/Scp096Mask/README.md
@@ -1,0 +1,10 @@
+Scp096Mask plugin
+
+Build: use msbuild or dotnet with references provided by EXILED (set EXILED_REFERENCES env var to point dlls).
+
+Features:
+- Medkits used as SCP-096 masks with distinct scale/tint
+- Harmony patches to prevent aggro and observation while masked
+- Configurable spawn chances per zone or specific rooms
+- Hotkey (ServerSpecificSettings) or NoClip toggle to interact
+- Commands: spawn, info, give, givepickup, remove, list

--- a/Scp096Mask/Scp096Mask.csproj
+++ b/Scp096Mask/Scp096Mask.csproj
@@ -1,0 +1,78 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <AssemblyName>Scp096Mask</AssemblyName>
+    <RootNamespace>Scp096Mask</RootNamespace>
+    <OutputType>Library</OutputType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(EXILED_REFERENCES)/Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>$(EXILED_REFERENCES)/Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Mirror">
+      <HintPath>$(EXILED_REFERENCES)/Mirror.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(EXILED_REFERENCES)/UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule">
+      <HintPath>$(EXILED_REFERENCES)/UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>$(EXILED_REFERENCES)/UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>$(EXILED_REFERENCES)/UnityEngine.AudioModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Exiled.API">
+      <HintPath>$(EXILED_REFERENCES)/Exiled.API.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Exiled.Events">
+      <HintPath>$(EXILED_REFERENCES)/Exiled.Events.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Exiled.Loader">
+      <HintPath>$(EXILED_REFERENCES)/Exiled.Loader.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="HarmonyLib">
+      <HintPath>$(EXILED_REFERENCES)/0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="MEC">
+      <HintPath>$(EXILED_REFERENCES)/MEC.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UserSettings">
+      <HintPath>$(EXILED_REFERENCES)/UserSettings.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="HintServiceMeow.Core">
+      <HintPath>$(EXILED_REFERENCES)/HintServiceMeow.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="CommandSystem.Core">
+      <HintPath>$(EXILED_REFERENCES)/CommandSystem.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**/*.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds an SCP-096 mask plugin that prevents rage/aggro when equipped, with custom spawn mechanics and visual differentiation for the mask item.

This PR implements a complete plugin for SCP: Secret Laboratory, allowing players to equip SCP-096 with a mask (visually represented as a stretched and tinted medkit) to prevent its rage, observation, and targeting. The plugin includes configurable spawn chances for masks based on zones or specific rooms, along with administrative commands for managing masks and a player interaction system via keybind or noclip toggle.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe4ac1ce-4b1a-477a-9194-8c8aabc861f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe4ac1ce-4b1a-477a-9194-8c8aabc861f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

